### PR TITLE
Fix Netlify deploy preview blog links

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,3 @@
-baseURL: https://dannyguo.com
 disqusShortname: dannyguo
 googleAnalytics: UA-90320718-1
 languageCode: en-us


### PR DESCRIPTION
In the deploy previews, all the blog links use the configured base URL instead of the Netlify generated URL (e.g. https://5b0b7fa8b13fb11d38119aea--dannyguo.netlify.com). This means that clicking a blog post link opens up the production website rather than staying on the deploy preview.

Removing the baseURL setting fixes the issue and doesn't seem to have any adverse effects as nothing currently needs it.