### PR TITLE
Support unlisted posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Many of these were easy to add because of Hugo.
 * [static copyright year](https://github.com/dguo/dguo.github.io/commit/a8a3e1acac919f759253f07ad8a466be8ba4fcfb)
 * [static syntax highlighting](https://github.com/dguo/dguo.github.io/commit/3f02ffcd82883de75ac68151b1b518b045fb390b)
 * ["Updated on" dates](https://github.com/dguo/dguo.github.io/commit/86db8a3831508876bd8836573af3e752300e07c1) for blog posts when applicable
+* unlisted posts that are only publicly available through a direct link
 
 ## Content
 
@@ -47,10 +48,25 @@ Many of these were easy to add because of Hugo.
 * [mini blog of issues I've run into while programming](https://www.dannyguo.com/friction/)
 * [referral links](https://wwww.dannyguo.com/referrals/)
 
-## Checklist for Publishing a Post
+## Checklist for Publishing an Unlisted Post
+
+Follow this checklist to make a post publicly available, but only through a
+direct link. Nothing on the site should link to it. This concept is the same as
+an [unlisted YouTube video](https://support.google.com/youtube/answer/157177) or
+[unlisted Medium
+post](https://help.medium.com/hc/en-us/articles/215552778-Unlisted-publishing).
+
+1. Remove the `draft` flag from the front matter
+2. Add an `unlisted` flag with a value of `true`
+3. Leave the `date`, `categories`, and `tags` fields empty
+4. Commit, and push to deploy
+
+## Checklist for Publishing a Final Post
 
 1. Upload any images to the dedicated [Imgur album](https://imgur.com/a/mA7JRWp)
-2. Publish the post by removing the `draft` flag
+2. Update the front matter
+    * Remove the `draft` or `unlisted` flag
+    * Set the `date`, `categories`, and `tags` fields
 3. Back up images in Google Drive
 4. [Import](https://medium.com/p/import) the post into [Medium](https://medium.com/@dannyguo)
     * Convert code blocks into [GitHub gists](https://gist.github.com/) and embed them

--- a/archetypes/blog.md
+++ b/archetypes/blog.md
@@ -1,7 +1,7 @@
 ---
 categories:
   -
-date: "{{ now.Format "2006-01-02" }}"
+date:
 draft: true
 tags:
   -

--- a/content/blog/better-cding.md
+++ b/content/blog/better-cding.md
@@ -1,4 +1,5 @@
 ---
+date:
 draft: true
 title: Better cd-ing
 ---

--- a/content/blog/credit-card-rewards.md
+++ b/content/blog/credit-card-rewards.md
@@ -1,4 +1,5 @@
 ---
+date:
 draft: true
 title: Credit Card Rewards
 ---

--- a/content/blog/debates.md
+++ b/content/blog/debates.md
@@ -1,7 +1,7 @@
 ---
 categories:
   -
-date: "2018-10-22"
+date:
 draft: true
 tags:
   -

--- a/content/blog/manage-your-dotfiles-and-configuration-with-git.md
+++ b/content/blog/manage-your-dotfiles-and-configuration-with-git.md
@@ -1,7 +1,7 @@
 ---
 categories:
   - programming
-date: "2019-01-06"
+date:
 draft: true
 tags:
   - dotfiles

--- a/content/blog/the-leap-from-computer-science-to-software-engineering.md
+++ b/content/blog/the-leap-from-computer-science-to-software-engineering.md
@@ -1,7 +1,7 @@
 ---
 categories:
   - programming
-date: "2018-07-28"
+date:
 draft: true
 tags:
   - computer science

--- a/content/blog/the-state-of-static-websites-in-2018.md
+++ b/content/blog/the-state-of-static-websites-in-2018.md
@@ -1,7 +1,7 @@
 ---
 categories:
   - programming
-date: "2018-10-30"
+date:
 draft: true
 tags:
   - webdev

--- a/content/blog/think-in-spectrums-rather-than-binaries.md
+++ b/content/blog/think-in-spectrums-rather-than-binaries.md
@@ -1,7 +1,7 @@
 ---
 categories:
   -
-date: "2019-01-02"
+date:
 draft: true
 tags:
   -

--- a/dev
+++ b/dev
@@ -106,6 +106,11 @@ new_parser = subparsers.add_parser('new', help='Generate a new blog post')
 new_parser.add_argument('title', help="title of the post in kebab-case")
 new_parser.set_defaults(func=new)
 
+@command('Serve the prod site locally')
+def prod(args, remaining):
+    Thread(target=open_in_browser).start()
+    run_command(['hugo', 'server', '--bind', '0.0.0.0'], True)
+
 @command('View the website in your browser')
 def view(args, remaining):
     webbrowser.open(LOCAL_SITE)

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -2,7 +2,7 @@
 {{/* https://forestry.io/blog/search-with-algolia-in-hugo/ */}}
 {{- $.Scratch.Add "index" slice -}}
 {{- $section := $.Site.GetPage "section" .Section }}
-{{- range .Site.AllPages -}}
+{{- range where .Site.AllPages "Params.unlisted" "!=" true -}}
   {{- if and (eq .Kind "page") (and (eq .Type "blog") (and (not .Draft) (not .Params.private))) -}}
     {{- $.Scratch.Add "index" (dict "objectID" .UniqueID "content" (htmlUnescape (trim (replace .Plain "\n" " ") " ")) "kind" .Kind "lastModifiedDate" (.Lastmod.Format "2006-01-02") "publishDate" (.PublishDate.Format "2006-01-02") "relativePermalink" .RelPermalink "title" (replace .Title "Danny Guo · " "") "type" .Type "weight" .Weight "section" .Section "tags" .Params.Tags "categories" .Params.Categories)}}
   {{- end -}}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,7 +1,7 @@
 {{ define "main" }}
     {{ partial "anchor.html" .Content }}
 
-    {{ range .Data.Pages.ByDate.Reverse }}
+    {{ range where .Data.Pages.ByDate.Reverse "Params.unlisted" "!=" true }}
         <p>
             <em>{{.Date.Format "2006-01-02"}}</em>
             &middot;

--- a/layouts/blog/rss.xml
+++ b/layouts/blog/rss.xml
@@ -12,7 +12,7 @@
     {{ with .OutputFormats.Get "RSS" }}
         {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{ end }}
-    {{ range .Pages }}
+    {{ range where .Pages "Params.unlisted" "!=" true }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -15,15 +15,19 @@
 
     <div class="clearfix">
         {{ with .PrevInSection }}
-            <span class="previous-link">
-                <a href="{{ .Permalink }}">← {{ .Title }}</a>
-            </span>
+            {{ if (not .Params.unlisted) }}
+                <span class="previous-link">
+                    <a href="{{ .Permalink }}">← {{ .Title }}</a>
+                </span>
+            {{ end }}
         {{ end }}
 
         {{ with .NextInSection }}
-            <span class="next-link">
-                <a href="{{ .Permalink }}">{{ .Title }} →</a>
-            </span>
+            {{ if (not .Params.unlisted) }}
+                <span class="next-link">
+                    <a href="{{ .Permalink }}">{{ .Title }} →</a>
+                </span>
+            {{ end }}
         {{ end }}
     </div>
 

--- a/layouts/sitemap.xml
+++ b/layouts/sitemap.xml
@@ -1,0 +1,21 @@
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range where .Data.Pages "Params.unlisted" "!=" true }}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+  </url>
+  {{ end }}
+</urlset>


### PR DESCRIPTION
These are posts that are only available through a direct link. Nothing on the site should link to them. This means filtering in the following places:

* RSS feed
* sitemap
* blog, tags, and categories indexes
* previous and next links in individual posts
* Algolia index